### PR TITLE
Lazy initialization of XZInputStream is needed for use in SequenceFile.Reader

### DIFF
--- a/src/main/java/io/sensesecure/hadoop/xz/XZCompressionInputStream.java
+++ b/src/main/java/io/sensesecure/hadoop/xz/XZCompressionInputStream.java
@@ -1,7 +1,9 @@
 package io.sensesecure.hadoop.xz;
 
-import java.io.*;
-
+import java.io.BufferedInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
 import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.io.compress.CompressionInputStream;
 import org.tukaani.xz.XZInputStream;
@@ -34,20 +36,6 @@ public class XZCompressionInputStream extends CompressionInputStream {
         return getInputStream().read(b, off, len);
     }
 
-    /**
-     * This compression stream ({@link #xzIn}) is initialized lazily, in case the
-     * data is not available at the time of initialization.  This is necessary
-     * for the codec to be used in a {@link SequenceFile.Reader}, as it constructs
-     * the {@link XZCompressionInputStream} before putting data into its buffer.
-     * Eager initialization of {@link #xzIn} there results in an {@link EOFException}.
-     */
-    private XZInputStream getInputStream() throws IOException {
-        if (xzIn == null) {
-            xzIn = new XZInputStream(bufferedIn);
-        }
-        return xzIn;
-    }
-
     @Override
     public void resetState() throws IOException {
         resetStateNeeded = true;
@@ -69,5 +57,19 @@ public class XZCompressionInputStream extends CompressionInputStream {
             }
             resetStateNeeded = true;
         }
+    }
+
+    /**
+     * This compression stream ({@link #xzIn}) is initialized lazily, in case the
+     * data is not available at the time of initialization.  This is necessary
+     * for the codec to be used in a {@link SequenceFile.Reader}, as it constructs
+     * the {@link XZCompressionInputStream} before putting data into its buffer.
+     * Eager initialization of {@link #xzIn} there results in an {@link EOFException}.
+     */
+    private XZInputStream getInputStream() throws IOException {
+        if (xzIn == null) {
+            xzIn = new XZInputStream(bufferedIn);
+        }
+        return xzIn;
     }
 }

--- a/src/main/java/io/sensesecure/hadoop/xz/XZCompressionInputStream.java
+++ b/src/main/java/io/sensesecure/hadoop/xz/XZCompressionInputStream.java
@@ -1,8 +1,8 @@
 package io.sensesecure.hadoop.xz;
 
-import java.io.BufferedInputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
+
+import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.io.compress.CompressionInputStream;
 import org.tukaani.xz.XZInputStream;
 
@@ -22,7 +22,6 @@ public class XZCompressionInputStream extends CompressionInputStream {
         super(in);
         resetStateNeeded = false;
         bufferedIn = new BufferedInputStream(super.in);
-        xzIn = new XZInputStream(bufferedIn);
     }
 
     @Override
@@ -30,9 +29,23 @@ public class XZCompressionInputStream extends CompressionInputStream {
         if (resetStateNeeded) {
             resetStateNeeded = false;
             bufferedIn = new BufferedInputStream(super.in);
+            xzIn = null;
+        }
+        return getInputStream().read(b, off, len);
+    }
+
+    /**
+     * This compression stream ({@link #xzIn}) is initialized lazily, in case the
+     * data is not available at the time of initialization.  This is necessary
+     * for the codec to be used in a {@link SequenceFile.Reader}, as it constructs
+     * the {@link XZCompressionInputStream} before putting data into its buffer.
+     * Eager initialization of {@link #xzIn} there results in an {@link EOFException}.
+     */
+    private XZInputStream getInputStream() throws IOException {
+        if (xzIn == null) {
             xzIn = new XZInputStream(bufferedIn);
         }
-        return xzIn.read(b, off, len);
+        return xzIn;
     }
 
     @Override
@@ -50,7 +63,10 @@ public class XZCompressionInputStream extends CompressionInputStream {
     @Override
     public void close() throws IOException {
         if (!resetStateNeeded) {
-            xzIn.close();
+            if (xzIn != null) {
+                xzIn.close();
+                xzIn = null;
+            }
             resetStateNeeded = true;
         }
     }

--- a/src/test/java/io/sensesecure/hadoop/xz/XZCodecTest.java
+++ b/src/test/java/io/sensesecure/hadoop/xz/XZCodecTest.java
@@ -1,26 +1,22 @@
 package io.sensesecure.hadoop.xz;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.Random;
-import org.apache.hadoop.io.DataInputBuffer;
-import org.apache.hadoop.io.DataOutputBuffer;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.*;
+import org.apache.hadoop.io.SequenceFile.CompressionType;
+import org.apache.hadoop.io.SequenceFile.Writer;
 import org.apache.hadoop.io.compress.CompressionInputStream;
 import org.apache.hadoop.io.compress.CompressionOutputStream;
 import org.apache.hadoop.io.compress.Compressor;
 import org.apache.hadoop.io.compress.Decompressor;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.*;
+import org.junit.rules.TemporaryFolder;
+
 import static org.junit.Assert.*;
 
 /**
@@ -52,6 +48,9 @@ public class XZCodecTest {
 
     public XZCodecTest() {
     }
+    
+    @Rule
+    public final TemporaryFolder folder = new TemporaryFolder();
 
     @BeforeClass
     public static void setUpClass() {
@@ -234,5 +233,66 @@ public class XZCodecTest {
             assertEquals("Inflated stream read by byte does not match",
                     expected, inflateFilter.read());
         } while (expected != -1);
+    }
+
+    @org.junit.Test
+    public void testSequenceFileCompressionDecompression() throws Exception {
+        System.out.println("Sequence File Compression/Decompression");
+        XZCodec codec = new XZCodec();
+
+        // Generate data and sequence file
+        final DataOutputBuffer data = new DataOutputBuffer();
+        final Configuration    conf = new Configuration();
+        final File             file = new File(folder.getRoot(), "test.seq");
+        final Path             path = new Path("file:"+file.getAbsolutePath());
+        try (Writer writer = SequenceFile.createWriter(conf,
+                Writer.file(path),
+                Writer.keyClass(RandomDatum.class),
+                Writer.valueClass(RandomDatum.class),
+                Writer.compression(CompressionType.BLOCK, codec))) {
+            RandomDatum.Generator generator = new RandomDatum.Generator(seed);
+            int numSyncs = 4;
+            for (int i = 0, syncEvery = count/(numSyncs+1), nextSync = syncEvery; i < count; ++i) {
+                generator.next();
+                RandomDatum key   = generator.getKey();
+                RandomDatum value = generator.getValue();
+                key.write(data);
+                value.write(data);
+                writer.append(key, value);
+                if (i >= nextSync) {
+                    // Ensure that the codec copes with multiple blocks per file
+                    writer.sync();
+                    nextSync += syncEvery;
+                }
+            }
+        }
+
+        // Read the sequence file and check its contents
+        DataInputBuffer originalData = new DataInputBuffer();
+        originalData.reset(data.getData(), 0, data.getLength());
+        DataInputStream originalIn = new DataInputStream(new BufferedInputStream(originalData));
+        try (SequenceFile.Reader reader = new SequenceFile.Reader(conf,
+                SequenceFile.Reader.file(path))) {
+            for (int i = 0; i < count; ++i) {
+                RandomDatum k1 = new RandomDatum();
+                RandomDatum v1 = new RandomDatum();
+                k1.readFields(originalIn);
+                v1.readFields(originalIn);
+                RandomDatum k2 = new RandomDatum();
+                RandomDatum v2 = new RandomDatum();
+                reader.next(k2, v2);
+                assertTrue("original and compressed-then-decompressed-output not equal",
+                    k1.equals(k2) && v1.equals(v2));
+
+                // original and compressed-then-decompressed-output have the same hashCode
+                Map<RandomDatum, String> m = new HashMap<>();
+                m.put(k1, k1.toString());
+                m.put(v1, v1.toString());
+                String result = m.get(k2);
+                assertEquals("k1 and k2 hashcode not equal", result, k1.toString());
+                result = m.get(v2);
+                assertEquals("v1 and v2 hashcode not equal", result, v1.toString());
+            }
+        }
     }
 }

--- a/src/test/java/io/sensesecure/hadoop/xz/XZCodecTest.java
+++ b/src/test/java/io/sensesecure/hadoop/xz/XZCodecTest.java
@@ -1,23 +1,35 @@
 package io.sensesecure.hadoop.xz;
 
-import java.io.*;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.Random;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.*;
+import org.apache.hadoop.io.DataInputBuffer;
+import org.apache.hadoop.io.DataOutputBuffer;
+import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.io.SequenceFile.CompressionType;
 import org.apache.hadoop.io.SequenceFile.Writer;
 import org.apache.hadoop.io.compress.CompressionInputStream;
 import org.apache.hadoop.io.compress.CompressionOutputStream;
 import org.apache.hadoop.io.compress.Compressor;
 import org.apache.hadoop.io.compress.Decompressor;
-import org.junit.*;
-import org.junit.rules.TemporaryFolder;
-
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
 
 /**
  *
@@ -44,7 +56,6 @@ public class XZCodecTest {
         (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00,
         (byte) 0x00, (byte) 0x04, (byte) 0x59, (byte) 0x5a,
         (byte) 0x0a};
-    private final byte[] uncompressedTestData = {'t', 'e', 's', 't'};
 
     public XZCodecTest() {
     }


### PR DESCRIPTION
I was working on this separately and found that eager initialization of XZInputStream causes some bytes to be read, but SequenceFile.Reader hasn't populated the underlying data yet.  We can work around SequenceFile.Reader's early initialization by initializing xzIn lazily.

Commit 6855aa47d9402695b97dda47f767dd42e02df768 adds a test (which fails) of the codec in sequence files.

Commit 337574dc40990285c5900f687169dd12c4f4d9a2 switches xzIn to lazy initialization, causing the test to pass.

Commit a1ff70872beee7165ebca9f638d4e0ca0e3bf10c is just a minor cleanup.
