### PR TITLE
when the XZCompressor is reused by the CodecPool (because multiple SE…

### DIFF
--- a/src/main/java/io/sensesecure/hadoop/xz/XZCompressor.java
+++ b/src/main/java/io/sensesecure/hadoop/xz/XZCompressor.java
@@ -62,7 +62,6 @@ public class XZCompressor implements Compressor {
 
     @Override
     public void reinit(Configuration conf) {
-        throw new UnsupportedOperationException("Not supported yet.");
+        // do nothing
     }
-
 }

--- a/src/test/java/io/sensesecure/hadoop/xz/XZCodecTest.java
+++ b/src/test/java/io/sensesecure/hadoop/xz/XZCodecTest.java
@@ -1,20 +1,5 @@
 package io.sensesecure.hadoop.xz;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.nio.file.Files;
-import java.util.Arrays;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.Random;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
@@ -35,8 +20,28 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import static org.junit.Assert.*;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  *
@@ -325,6 +330,69 @@ public class XZCodecTest {
                 assertEquals("k1 and k2 hashcode not equal", result, k1.toString());
                 result = m.get(v2);
                 assertEquals("v1 and v2 hashcode not equal", result, v1.toString());
+            }
+        }
+    }
+
+    @Test
+    public void testSequenceFileCompressionCompressorPooling() throws Exception {
+        System.out.println("Sequence File Compression/Decompression Compressor Pooling");
+        XZCodec codec = new XZCodec();
+
+        // Generate data and sequence file
+        final DataOutputBuffer data = new DataOutputBuffer();
+        final Configuration conf = new Configuration();
+        for (int j = 0; j < 2; j++) {
+            final File file = new File(folder.getRoot(), "test" + j + ".seq");
+            final Path path = new Path("file:" + file.getAbsolutePath());
+            try (Writer writer = SequenceFile.createWriter(conf,
+                    Writer.file(path),
+                    Writer.keyClass(RandomDatum.class),
+                    Writer.valueClass(RandomDatum.class),
+                    Writer.compression(CompressionType.BLOCK, codec))) {
+                RandomDatum.Generator generator = new RandomDatum.Generator(seed);
+                int numSyncs = 4;
+                for (int i = 0, syncEvery = count / (numSyncs + 1), nextSync = syncEvery; i < count; ++i) {
+                    generator.next();
+                    RandomDatum key = generator.getKey();
+                    RandomDatum value = generator.getValue();
+                    key.write(data);
+                    value.write(data);
+                    writer.append(key, value);
+                    if (i >= nextSync) {
+                        // Ensure that the codec copes with multiple blocks per file
+                        writer.sync();
+                        nextSync += syncEvery;
+                    }
+                }
+            }
+
+            // Read the sequence file and check its contents
+            DataInputBuffer originalData = new DataInputBuffer();
+            originalData.reset(data.getData(), 0, data.getLength());
+            DataInputStream originalIn = new DataInputStream(new BufferedInputStream(originalData));
+            try (SequenceFile.Reader reader = new SequenceFile.Reader(conf,
+                    SequenceFile.Reader.file(path))) {
+                for (int i = 0; i < count; ++i) {
+                    RandomDatum k1 = new RandomDatum();
+                    RandomDatum v1 = new RandomDatum();
+                    k1.readFields(originalIn);
+                    v1.readFields(originalIn);
+                    RandomDatum k2 = new RandomDatum();
+                    RandomDatum v2 = new RandomDatum();
+                    reader.next(k2, v2);
+                    assertTrue("original and compressed-then-decompressed-output not equal",
+                            k1.equals(k2) && v1.equals(v2));
+
+                    // original and compressed-then-decompressed-output have the same hashCode
+                    Map<RandomDatum, String> m = new HashMap<>();
+                    m.put(k1, k1.toString());
+                    m.put(v1, v1.toString());
+                    String result = m.get(k2);
+                    assertEquals("k1 and k2 hashcode not equal", result, k1.toString());
+                    result = m.get(v2);
+                    assertEquals("v1 and v2 hashcode not equal", result, v1.toString());
+                }
             }
         }
     }


### PR DESCRIPTION
…Q files are being written), the current implenentation would throw an UnsupportedOperation exception.  Since nothing is actually being done in the compressor, there is no need for the reinit() method to fail.  This allows multiple SEQ files to be correctly compressed.
